### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/nerdinand/chorbasel-app/security/code-scanning/4](https://github.com/nerdinand/chorbasel-app/security/code-scanning/4)

To fix this problem, add a top-level `permissions` block to limit the GITHUB_TOKEN's permissions in the workflow. The best practice is to set permissions to the minimum required for the jobs/steps. In this workflow, all jobs only appear to need to check out code and upload artifacts (which do not require elevated repository permissions beyond `contents: read`). Therefore, the optimal fix is to add:

```yaml
permissions:
  contents: read
```

at the top level, just below the `name` field but above `on:`. This will default all jobs to these restricted permissions.

**File/region/lines to change:**  
- File: .github/workflows/ci.yml  
- Lines: Insert after line 1 ("name: CI")

**Methods/imports/definitions needed:**  
- None; only a YAML configuration addition is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
