### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nerdinand/chorbasel-app/security/code-scanning/3](https://github.com/nerdinand/chorbasel-app/security/code-scanning/3)

To fix the problem, a `permissions` block should be added to the workflow, either at the top level (applying to all jobs) or specifically to jobs that don't need more than the default. The minimal recommended setting is `contents: read`, which suffices for checking out code and running analyses but does not allow writing code, creating releases, or opening issues. This should be added at the root of the workflow file, immediately after the `name` declaration and before the `on:` trigger, ensuring all jobs inherit this block unless they specifically override it. No additional YAML features, syntax, or indentation changes are needed beyond this addition. No package changes or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
