### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nerdinand/chorbasel-app/security/code-scanning/2](https://github.com/nerdinand/chorbasel-app/security/code-scanning/2)

To address this issue, the best fix is to add an explicit `permissions` block near the root of the workflow file, directly under the top-level fields (such as under the `name:` and before the `on:` or `jobs:` blocks), setting `permissions: contents: read`. This will restrict the GITHUB_TOKEN used by Actions to have only read access to the repository contents across all jobs, unless overridden by a more specific job-level setting. No other changes to job blocks or steps are needed, and this action has no impact on existing job functionality because none of the jobs require write permissions. Edit the file `.github/workflows/ci.yml` at the root level to include this permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
